### PR TITLE
Allow buffer size to be tuned

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -82,7 +82,7 @@ default['haproxy']['source']['use_pcre'] = false
 default['haproxy']['source']['use_openssl'] = false
 default['haproxy']['source']['use_zlib'] = false
 
-default['haproxy']['perf']['buffer_size'] = 16384
+default['haproxy']['perf']['buffer_size'] = nil
 
 default['haproxy']['listeners'] = {
   'listen' => {},

--- a/templates/default/haproxy.cfg.erb
+++ b/templates/default/haproxy.cfg.erb
@@ -9,7 +9,10 @@ global
 <% if node['haproxy']['enable_stats_socket'] -%>
   stats socket <%= node['haproxy']['stats_socket_path'] %> user <%= node['haproxy']['stats_socket_user'] %> group <%= node['haproxy']['stats_socket_group'] %>
 <% end -%>
+<% if node['haproxy']['perf']['buffer_size'] -%>
   tune.bufsize <%= node['haproxy']['perf']['buffer_size'] %>
+<% end -%>
+
 
 defaults
   log     global


### PR DESCRIPTION
Adds a line to the haproxy.cfg template which allows tuning of the buffer size used for each connection.

Defaults to the value which would be used if property isn't overridden in the config.
